### PR TITLE
PN-19664: fix @Async return type incompatible with Spring Framework 6

### DIFF
--- a/src/main/java/it/gov/pagopa/logextractor/service/LogService.java
+++ b/src/main/java/it/gov/pagopa/logextractor/service/LogService.java
@@ -21,11 +21,10 @@ public interface LogService {
 	 * Service method that retrieves the anonymized logs related to a person's activities history in a period
 	 * or to a notification's activities history within 3 months from its legal start date
 	 * @param requestData the input data of type {@link PersonLogsRequestDto}
-	 * @return 
 	 * @throws IOException in case of an IO error
 	 */
 	@Async
-	String getAnonymizedPersonLogs(String key, String pass, PersonLogsRequestDto requestData,
+	void getAnonymizedPersonLogs(String key, String pass, PersonLogsRequestDto requestData,
 											String xPagopaHelpdUid,
 											String xPagopaCxType) throws IOException;
 	

--- a/src/main/java/it/gov/pagopa/logextractor/service/LogServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/logextractor/service/LogServiceImpl.java
@@ -82,7 +82,7 @@ public class LogServiceImpl implements LogService {
 
 	@Override
 	@Async
-	public String getAnonymizedPersonLogs(String key, String pass, PersonLogsRequestDto requestData, String xPagopaHelpdUid, String xPagopaCxType)
+	public void getAnonymizedPersonLogs(String key, String pass, PersonLogsRequestDto requestData, String xPagopaHelpdUid, String xPagopaCxType)
 			throws IOException {
 		log.info(
 				"Anonymized logs retrieve process - START - user={}, userType={}, ticketNumber={}, "
@@ -133,7 +133,6 @@ public class LogServiceImpl implements LogService {
 		}
 		zipService.close(zipInfo);
 		log.info(LoggingConstants.ANONYMIZED_RETRIEVE_PROCESS_END, (System.currentTimeMillis() - serviceStartTime));
-		return zipInfo.getPassword();
 	}
 
 	@Override


### PR DESCRIPTION
getAnonymizedPersonLogs declared String as return type for an @Async method. Spring 6 only supports void, Future or CompletableFuture for async methods, causing IllegalArgumentException at runtime on every call to POST /logs/v1/persons.

The return value was already unused by the caller (LogController generates zipPassword locally before the call and uses it directly in the response).